### PR TITLE
GIRD-9/UR-100 Updates

### DIFF
--- a/Pocket Edition/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/EarlyMissions/GIRD-9.cfg
+++ b/Pocket Edition/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/EarlyMissions/GIRD-9.cfg
@@ -13,14 +13,14 @@ CONTRACT_TYPE
 
 	agent = BeforeSputnik
 	minExpiry = 0
-	prestige = trivial
+	prestige = exceptional
 	cancellable = true
 	declinable = true
 	targetBody = HomeWorld()
 	maxCompletions = 1
 	maxSimultaneous = 1
 	rewardScience = 1
-	rewardReputation = 3
+	rewardReputation = 1
 	rewardFunds = @HistoryofSpaceflight:Kerbucks025
 	failureFunds = @HistoryofSpaceflight:Kerbucks025
 	advanceFunds = @HistoryofSpaceflight:Kerbucks025
@@ -28,32 +28,38 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = double
-//		Altitude = 400
-		Altitude = 0.008 * (HomeWorld().FlyingAltitudeThreshold())
+		RealMaxAltitude = 5000
+	}
+
+	DATA
+	{
+		type = double
+		// Altitude = 400
+		Altitude = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 400 : 0.00286 * (HomeWorld().AtmosphereAltitude()))
 		title = Altitude
 	}
 
 	DATA
 	{
 		type = double
-//		MaxAltitude = 5000
-		MaxAltitude = 0.1 * (HomeWorld().FlyingAltitudeThreshold())
+		// MaxAltitude = 5000
+		MaxAltitude = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 5000 : 0.00357 * (HomeWorld().AtmosphereAltitude()))
 		title = MaxAltitude
 	}
 
 	DATA
 	{
 		type = double
-//		MaxDeltaVee = 800
-		MaxDeltaVee = 0.016 * (HomeWorld().FlyingAltitudeThreshold())
+		// MaxDeltaVee = 765
+		MaxDeltaVee = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 765 * 1.05 : 0.00546 * (HomeWorld().AtmosphereAltitude())) * 1.05
 		title = MaxDeltaVee
 	}
 
 	DATA
 	{
 		type = double
-//		MinSpeed = 275
-		MinSpeed = 0.00196 * (HomeWorld().AtmosphereAltitude())
+		// MinSpeed = 275
+		MinSpeed = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 275 : 0.00196 * (HomeWorld().AtmosphereAltitude()))
 		title = MinSpeed
 	}
 
@@ -63,6 +69,7 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Launch the GIRD-9 test rocket to @/Altitude m altitude
 		define = GIRD-9
+		disableOnStateChange = True
 
 		PARAMETER
 		{
@@ -80,59 +87,58 @@ CONTRACT_TYPE
 		}
 	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minDeltaVeeActual = 1
-			maxDeltaVeeActual = @/MaxDeltaVee
-			disableOnStateChange = True
-			situation = PRELAUNCH
-			title = Don't exceed @/MaxDeltaVee m/s delta-V (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		maxDeltaVeeVacuum = @/MaxDeltaVee
+		disableOnStateChange = True
+		situation = PRELAUNCH
+                title = Don't exceed @/MaxDeltaVee m/s (vac) delta-V  (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minTerrainAltitude = @/Altitude
-			disableOnStateChange = True
-			situation = FLYING
-			title = Reach at least @/Altitude m altitude
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minTerrainAltitude = @/Altitude
+		disableOnStateChange = True
+		situation = FLYING
+		title = Reach at least @/Altitude m altitude
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minSpeed = @/MinSpeed
-			disableOnStateChange = True
-			situation = FLYING
-			title = Reach at least @/MinSpeed m/s velocity (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minSpeed = @/MinSpeed
+		disableOnStateChange = True
+		situation = FLYING
+		title = Reach at least @/MinSpeed m/s velocity (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minRateOfClimb = -1
-			maxRateOfClimb = 1
-			minAltitude = @/MaxAltitude * 0.95
-			maxAltitude = @/MaxAltitude * 1.05
-			disableOnStateChange = true
-			situation = FLYING
-			title = Don't exceed @/MaxAltitude m maximum apogee (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minRateOfClimb = -1
+		maxRateOfClimb = 1
+		minAltitude = @/MaxAltitude
+		maxAltitude = @/MaxAltitude * 1.05
+		disableOnStateChange = true
+		situation = FLYING
+		title = Don't exceed @/MaxAltitude m maximum apogee (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
 	PARAMETER
 	{

--- a/Pocket Edition/Gamedata/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/BallisticMissileTests/UR-100.cfg
+++ b/Pocket Edition/Gamedata/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/BallisticMissileTests/UR-100.cfg
@@ -1,78 +1,167 @@
 CONTRACT_TYPE
 {
-    name = UR-100
-	group= SovietLauncherMissions		
-	title = UR-100
+        name = UR-100
+        group= SovietLauncherMissions
+        title = UR-100
 
-	description = The UR-100 was a two-stage liquid-propellant lightweight ICBM. It was the Soviet answer to the US Minuteman and was deployed in larger numbers than any other in history. Initial versions carried a single warhead of 0.5 to 1.1 Mt yield, while later versions could carry three or six MIRV warheads. The missile was silo-launched. 15P784 silo design (by KBOM, Design Bureau of Common Machinery, of V.P.Barmin) was greatly simplified in comparison to earlier missiles. Facilities consisted of hardened, un-manned silos controlled by a single central command post. This was the first soviet ICBM (8K84M, entered service on 3 October 1971) equipped with missile defense countermeasure "Palma" by NII-108 of V.Gerasimenko. The UR-100 had a range up to 11,000 km with a light (770 kg) warhead, and a range of 4,000 km with a heavy (1,750 kg) warhead.
+        description = The UR-100 was a two-stage liquid-propellant lightweight ICBM. It was the Soviet answer to the US Minuteman and was deployed in larger numbers than any other in history. Initial versions carried a single warhead of 0.5 to 1.1 Mt yield, while later versions could carry three or six MIRV warheads. The missile was silo-launched. 15P784 silo design (by KBOM, Design Bureau of Common Machinery, of V.P.Barmin) was greatly simplified in comparison to earlier missiles. Facilities consisted of hardened, un-manned silos controlled by a single central command post. This was the first soviet ICBM (8K84M, entered service on 3 October 1971) equipped with missile defense countermeasure "Palma" by NII-108 of V.Gerasimenko. The UR-100 had a range up to 11,000 km with a light (770 kg) warhead, and a range of 4,000 km with a heavy (1,750 kg) warhead. &br;&br; Payload: 770 - 1750 kg&br; Gross mass: 41,410 kg&br; Thrust: 785 kN&br; Height: 16.93 m&br; Diameter: 2.00 m&br; Max Apogee: 1,000 km.
 
-	notes = Launch the UR-100 ICBM to @/Altitude m altitude.
-	synopsis = <color=yellow>The UR-100 made its first test flight on January 1, 1965 at the Tyuratam, Plesetsk Launch Complex.</color>
-	completedMessage = Mission Success!
+        notes = Launch the UR-100 ICBM to @/Altitude m altitude.
+        synopsis = <color=yellow>The UR-100 made its first test flight on January 1, 1965 at the Tyuratam, Plesetsk Launch Complex.</color>
+        completedMessage = Mission Success!
+        sortKey = 19650101
 
-	agent = USSR
-	deadline = 90
-	minExpiry = 90
-	maxExpiry = 90
-	prestige = trivial
-	cancellable = true
-	declinable = true
-	maxCompletions = 1
-	maxSimultaneous = 1
-	rewardScience = 1
-	rewardReputation = 5
-	rewardFunds = @HistoryofSpaceflight:Kerbucks05
-	failureFunds = @HistoryofSpaceflight:Kerbucks05
-	advanceFunds = @HistoryofSpaceflight:Kerbucks05
+        agent = USSR
+        minExpiry = 0
+        prestige = trivial
+        cancellable = true
+        declinable = true
+        targetBody = HomeWorld()
+        maxCompletions = 1
+        maxSimultaneous = 1
+        rewardScience = 1
+        rewardReputation = 3
+        rewardFunds = @HistoryofSpaceflight:Kerbucks1
+        failureFunds = @HistoryofSpaceflight:Kerbucks1
+        advanceFunds = @HistoryofSpaceflight:Kerbucks1
 
-	DATA
-	{
-		type = double
-		Altitude = 6.429 * (HomeWorld().AtmosphereAltitude())
-		title = Altitude
-	}
+        DATA
+        {
+                type = double
+                // Altitude = 1000km
+                Altitude = (7.143 * (HomeWorld().AtmosphereAltitude())) < HomeWorld().AtmosphereAltitude() ? HomeWorld().AtmosphereAltitude() : (7.143 * (HomeWorld().AtmosphereAltitude()))
+                title = Altitude
+        }
+
+        DATA
+        {
+                type = double
+                // MaxDeltaVee = 6000
+                MaxDeltaVee = 0.0428 * (HomeWorld().AtmosphereAltitude()) * 1.05
+                title = MaxDeltaVee
+        }
+
+        DATA
+        {
+                type = double
+                // MinSpeed = 3100
+                MinSpeed = 0.0221 * (HomeWorld().AtmosphereAltitude())
+                title = MinSpeed
+        }
+
+        PARAMETER
+        {
+                name = UR-100
+                type = VesselParameterGroup
+                title = Launch the UR-100 to @/Altitude m altitude
+                define = UR-100
+                disableOnStateChange = True
+
+                PARAMETER
+                {
+                        name = NewVessel
+                        type = NewVessel
+                        hidden = true
+                }
+
+                PARAMETER
+                {
+                        name = Crewmembers
+                        type = HasCrew
+                        minCrew = 0
+                        maxCrew = 0
+                }
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                maxDeltaVeeVacuum = @/MaxDeltaVee
+                disableOnStateChange = True
+                situation = PRELAUNCH
+                title = Don't exceed @/MaxDeltaVee m/s (vac) delta-V  (bonus)
+                optional = true
+                rewardReputation = 1
+        }
 
 	PARAMETER
 	{
-        name = UR-100
-        type = VesselParameterGroup
-        title = Launch the UR-100 to @/Altitude m altitude
-        define = UR-100
-
-		PARAMETER 
-		{
-			name = NewVessel
-			type = NewVessel
-			hidden = true
-		}
-
-		PARAMETER
-		{
-			name = Crewmembers
-			type = HasCrew
-			minCrew = 0
-			maxCrew = 0
-		}
-
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			minAltitude = @/Altitude
-			disableOnStateChange = True
-			situation = SUB_ORBITAL
-			title = Reach at least @/Altitude m altitude
-			hideChildren = true
-		}
+		name = PartValidation
+		type = PartValidation
+		part = SmallTank
+		minCount = 1
+		disableOnStateChange = true
+		title = Have 770 kg ore payload (bonus)
+                optional = true
+                rewardReputation = 1
 	}
 
-	REQUIREMENT
-	{
-        name = CompleteContract
-        type = CompleteContract
-        contractType = Zond-2
-        minCount =1
-        maxCount =1
-        cooldownDuration = 0d
-	}
-}    
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minSpeed = @/MinSpeed
+                disableOnStateChange = True
+                situation = FLYING
+                situation = SUB_ORBITAL
+                title = Reach at least @/MinSpeed m/s velocity (bonus)
+                optional = true
+                rewardReputation = 1
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minAltitude = @/Altitude
+                disableOnStateChange = True
+                situation = SUB_ORBITAL
+                title = Reach at least @/Altitude m altitude
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minRateOfClimb = -1
+                maxRateOfClimb = 1
+                minAltitude = @/Altitude
+                maxAltitude = @/Altitude * 1.05
+                disableOnStateChange = true
+                situation = SUB_ORBITAL
+                title = Don't exceed @/Altitude m maximum apogee (bonus)
+                optional = true
+                rewardReputation = 1
+        }
+
+        PARAMETER
+        {
+                name = VesselDestroyed
+                type = VesselDestroyed
+                vessel = UR-100
+                mustImpactTerrain = false
+                title = UR-100 destroyed
+        }
+
+        REQUIREMENT
+        {
+                name = CompleteContract
+                type = CompleteContract
+                contractType = Zond-2
+                minCount =1
+                maxCount =1
+                cooldownDuration = 0d
+        }
+
+        BEHAVIOUR
+        {
+                name = ExperimentalPart
+                type = ExperimentalPart
+                part = SmallTank
+        }
+}

--- a/RSS/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/BallisticMissileTests/UR-100.cfg
+++ b/RSS/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/BallisticMissileTests/UR-100.cfg
@@ -1,77 +1,167 @@
 CONTRACT_TYPE
 {
-    name = UR-100
-	group= SovietLauncherMissions		
-	title = UR-100
+        name = UR-100
+        group= SovietLauncherMissions
+        title = UR-100
 
-	description = The UR-100 was a two-stage liquid-propellant lightweight ICBM. It was the Soviet answer to the US Minuteman and was deployed in larger numbers than any other in history. Initial versions carried a single warhead of 0.5 to 1.1 Mt yield, while later versions could carry three or six MIRV warheads. The missile was silo-launched. 15P784 silo design (by KBOM, Design Bureau of Common Machinery, of V.P.Barmin) was greatly simplified in comparison to earlier missiles. Facilities consisted of hardened, un-manned silos controlled by a single central command post. This was the first soviet ICBM (8K84M, entered service on 3 October 1971) equipped with missile defense countermeasure "Palma" by NII-108 of V.Gerasimenko. The UR-100 had a range up to 11,000 km with a light (770 kg) warhead, and a range of 4,000 km with a heavy (1,750 kg) warhead.
+        description = The UR-100 was a two-stage liquid-propellant lightweight ICBM. It was the Soviet answer to the US Minuteman and was deployed in larger numbers than any other in history. Initial versions carried a single warhead of 0.5 to 1.1 Mt yield, while later versions could carry three or six MIRV warheads. The missile was silo-launched. 15P784 silo design (by KBOM, Design Bureau of Common Machinery, of V.P.Barmin) was greatly simplified in comparison to earlier missiles. Facilities consisted of hardened, un-manned silos controlled by a single central command post. This was the first soviet ICBM (8K84M, entered service on 3 October 1971) equipped with missile defense countermeasure "Palma" by NII-108 of V.Gerasimenko. The UR-100 had a range up to 11,000 km with a light (770 kg) warhead, and a range of 4,000 km with a heavy (1,750 kg) warhead. &br;&br; Payload: 770 - 1750 kg&br; Gross mass: 41,410 kg&br; Thrust: 785 kN&br; Height: 16.93 m&br; Diameter: 2.00 m&br; Max Apogee: 1,000 km.
 
-	notes = Launch the UR-100 ICBM to 900 km altitude and reach 9,000 km downrange.
-	synopsis = <color=yellow>The UR-100 made its first test flight on January 1, 1965 at the Tyuratam, Plesetsk Launch Complex.</color>
-	completedMessage = Mission Success!
+        notes = Launch the UR-100 ICBM to @/Altitude m altitude.
+        synopsis = <color=yellow>The UR-100 made its first test flight on January 1, 1965 at the Tyuratam, Plesetsk Launch Complex.</color>
+        completedMessage = Mission Success!
+        sortKey = 19650101
 
-	agent = USSR
-	deadline = 90
-	minExpiry = 90
-	maxExpiry = 90
-	prestige = trivial
-	cancellable = true
-	declinable = true
-	maxCompletions = 1
-	maxSimultaneous = 1
-	rewardScience = 1
-	rewardReputation = 5
-	rewardFunds = 20000
-	failureFunds = 3000
-	advanceFunds = 10000
+        agent = USSR
+        minExpiry = 0
+        prestige = trivial
+        cancellable = true
+        declinable = true
+        targetBody = HomeWorld()
+        maxCompletions = 1
+        maxSimultaneous = 1
+        rewardScience = 1
+        rewardReputation = 3
+        rewardFunds = @HistoryofSpaceflight:Kerbucks1
+        failureFunds = @HistoryofSpaceflight:Kerbucks1
+        advanceFunds = @HistoryofSpaceflight:Kerbucks1
+
+        DATA
+        {
+                type = double
+                // Altitude = 1000km
+                Altitude = (7.143 * (HomeWorld().AtmosphereAltitude())) < HomeWorld().AtmosphereAltitude() ? HomeWorld().AtmosphereAltitude() : (7.143 * (HomeWorld().AtmosphereAltitude()))
+                title = Altitude
+        }
+
+        DATA
+        {
+                type = double
+                // MaxDeltaVee = 6000
+                MaxDeltaVee = 0.0428 * (HomeWorld().AtmosphereAltitude()) * 1.05
+                title = MaxDeltaVee
+        }
+
+        DATA
+        {
+                type = double
+                // MinSpeed = 3100
+                MinSpeed = 0.0221 * (HomeWorld().AtmosphereAltitude())
+                title = MinSpeed
+        }
+
+        PARAMETER
+        {
+                name = UR-100
+                type = VesselParameterGroup
+                title = Launch the UR-100 to @/Altitude m altitude
+                define = UR-100
+                disableOnStateChange = True
+
+                PARAMETER
+                {
+                        name = NewVessel
+                        type = NewVessel
+                        hidden = true
+                }
+
+                PARAMETER
+                {
+                        name = Crewmembers
+                        type = HasCrew
+                        minCrew = 0
+                        maxCrew = 0
+                }
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                maxDeltaVeeVacuum = @/MaxDeltaVee
+                disableOnStateChange = True
+                situation = PRELAUNCH
+                title = Don't exceed @/MaxDeltaVee m/s (vac) delta-V  (bonus)
+                optional = true
+                rewardReputation = 1
+        }
 
 	PARAMETER
 	{
-        name = UR-100
-        type = VesselParameterGroup
-        title = Launch the UR-100 to 900 km altitude
-        define = UR-100
-
-		PARAMETER 
-		{
-			name = NewVessel
-			type = NewVessel
-			hidden = true
-		}
-
-		PARAMETER
-		{
-			name = Crewmembers
-			type = HasCrew
-			minCrew = 0
-			maxCrew = 0
-		}
-
-		PARAMETER
-		{
-			name = ReachState   
-			type = ReachState  
-			situation = SUB_ORBITAL
-			minAltitude = 900000
-			maxAltitude = 1050000
-		}
-
-		PARAMETER:NEEDS[RP-0]
-		{
-			name = ReachDistance
-			type = DownrangeDistance
-			distance = 9000000.0
-			title = Reach 9,000 km Downrange
-		}
+		name = PartValidation
+		type = PartValidation
+		part = SmallTank
+		minCount = 1
+		disableOnStateChange = true
+		title = Have 770 kg ore payload (bonus)
+                optional = true
+                rewardReputation = 1
 	}
 
-	REQUIREMENT
-	{
-        name = CompleteContract
-        type = CompleteContract
-        contractType = Zond-2
-        minCount =1
-        maxCount =1
-        cooldownDuration = 0d
-	}
-}    
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minSpeed = @/MinSpeed
+                disableOnStateChange = True
+                situation = FLYING
+                situation = SUB_ORBITAL
+                title = Reach at least @/MinSpeed m/s velocity (bonus)
+                optional = true
+                rewardReputation = 1
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minAltitude = @/Altitude
+                disableOnStateChange = True
+                situation = SUB_ORBITAL
+                title = Reach at least @/Altitude m altitude
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minRateOfClimb = -1
+                maxRateOfClimb = 1
+                minAltitude = @/Altitude
+                maxAltitude = @/Altitude * 1.05
+                disableOnStateChange = true
+                situation = SUB_ORBITAL
+                title = Don't exceed @/Altitude m maximum apogee (bonus)
+                optional = true
+                rewardReputation = 1
+        }
+
+        PARAMETER
+        {
+                name = VesselDestroyed
+                type = VesselDestroyed
+                vessel = UR-100
+                mustImpactTerrain = false
+                title = UR-100 destroyed
+        }
+
+        REQUIREMENT
+        {
+                name = CompleteContract
+                type = CompleteContract
+                contractType = Zond-2
+                minCount =1
+                maxCount =1
+                cooldownDuration = 0d
+        }
+
+        BEHAVIOUR
+        {
+                name = ExperimentalPart
+                type = ExperimentalPart
+                part = SmallTank
+        }
+}

--- a/RSS/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/EarlyMissions/GIRD-9.cfg
+++ b/RSS/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/EarlyMissions/GIRD-9.cfg
@@ -13,14 +13,14 @@ CONTRACT_TYPE
 
 	agent = BeforeSputnik
 	minExpiry = 0
-	prestige = trivial
+	prestige = exceptional
 	cancellable = true
 	declinable = true
 	targetBody = HomeWorld()
 	maxCompletions = 1
 	maxSimultaneous = 1
 	rewardScience = 1
-	rewardReputation = 3
+	rewardReputation = 1
 	rewardFunds = @HistoryofSpaceflight:Kerbucks025
 	failureFunds = @HistoryofSpaceflight:Kerbucks025
 	advanceFunds = @HistoryofSpaceflight:Kerbucks025
@@ -28,32 +28,38 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = double
-//		Altitude = 400
-		Altitude = 0.008 * (HomeWorld().FlyingAltitudeThreshold())
+		RealMaxAltitude = 5000
+	}
+
+	DATA
+	{
+		type = double
+		// Altitude = 400
+		Altitude = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 400 : 0.00286 * (HomeWorld().AtmosphereAltitude()))
 		title = Altitude
 	}
 
 	DATA
 	{
 		type = double
-//		MaxAltitude = 5000
-		MaxAltitude = 0.1 * (HomeWorld().FlyingAltitudeThreshold())
+		// MaxAltitude = 5000
+		MaxAltitude = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 5000 : 0.00357 * (HomeWorld().AtmosphereAltitude()))
 		title = MaxAltitude
 	}
 
 	DATA
 	{
 		type = double
-//		MaxDeltaVee = 800
-		MaxDeltaVee = 0.016 * (HomeWorld().FlyingAltitudeThreshold())
+		// MaxDeltaVee = 765
+		MaxDeltaVee = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 765 * 1.05 : 0.00546 * (HomeWorld().AtmosphereAltitude())) * 1.05
 		title = MaxDeltaVee
 	}
 
 	DATA
 	{
 		type = double
-//		MinSpeed = 275
-		MinSpeed = 0.00196 * (HomeWorld().AtmosphereAltitude())
+		// MinSpeed = 275
+		MinSpeed = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 275 : 0.00196 * (HomeWorld().AtmosphereAltitude()))
 		title = MinSpeed
 	}
 
@@ -63,6 +69,7 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Launch the GIRD-9 test rocket to @/Altitude m altitude
 		define = GIRD-9
+		disableOnStateChange = True
 
 		PARAMETER
 		{
@@ -80,59 +87,58 @@ CONTRACT_TYPE
 		}
 	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minDeltaVeeActual = 1
-			maxDeltaVeeActual = @/MaxDeltaVee
-			disableOnStateChange = True
-			situation = PRELAUNCH
-			title = Don't exceed @/MaxDeltaVee m/s delta-V (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		maxDeltaVeeVacuum = @/MaxDeltaVee
+		disableOnStateChange = True
+		situation = PRELAUNCH
+                title = Don't exceed @/MaxDeltaVee m/s (vac) delta-V  (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minTerrainAltitude = @/Altitude
-			disableOnStateChange = True
-			situation = FLYING
-			title = Reach at least @/Altitude m altitude
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minTerrainAltitude = @/Altitude
+		disableOnStateChange = True
+		situation = FLYING
+		title = Reach at least @/Altitude m altitude
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minSpeed = @/MinSpeed
-			disableOnStateChange = True
-			situation = FLYING
-			title = Reach at least @/MinSpeed m/s velocity (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minSpeed = @/MinSpeed
+		disableOnStateChange = True
+		situation = FLYING
+		title = Reach at least @/MinSpeed m/s velocity (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minRateOfClimb = -1
-			maxRateOfClimb = 1
-			minAltitude = @/MaxAltitude * 0.95
-			maxAltitude = @/MaxAltitude * 1.05
-			disableOnStateChange = true
-			situation = FLYING
-			title = Don't exceed @/MaxAltitude m maximum apogee (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minRateOfClimb = -1
+		maxRateOfClimb = 1
+		minAltitude = @/MaxAltitude
+		maxAltitude = @/MaxAltitude * 1.05
+		disableOnStateChange = true
+		situation = FLYING
+		title = Don't exceed @/MaxAltitude m maximum apogee (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
 	PARAMETER
 	{

--- a/Stock/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/BallisticMissileTests/UR-100.cfg
+++ b/Stock/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/BallisticMissileTests/UR-100.cfg
@@ -1,78 +1,167 @@
 CONTRACT_TYPE
 {
-    name = UR-100
-	group= SovietLauncherMissions		
-	title = UR-100
+        name = UR-100
+        group= SovietLauncherMissions
+        title = UR-100
 
-	description = The UR-100 was a two-stage liquid-propellant lightweight ICBM. It was the Soviet answer to the US Minuteman and was deployed in larger numbers than any other in history. Initial versions carried a single warhead of 0.5 to 1.1 Mt yield, while later versions could carry three or six MIRV warheads. The missile was silo-launched. 15P784 silo design (by KBOM, Design Bureau of Common Machinery, of V.P.Barmin) was greatly simplified in comparison to earlier missiles. Facilities consisted of hardened, un-manned silos controlled by a single central command post. This was the first soviet ICBM (8K84M, entered service on 3 October 1971) equipped with missile defense countermeasure "Palma" by NII-108 of V.Gerasimenko. The UR-100 had a range up to 11,000 km with a light (770 kg) warhead, and a range of 4,000 km with a heavy (1,750 kg) warhead.
+        description = The UR-100 was a two-stage liquid-propellant lightweight ICBM. It was the Soviet answer to the US Minuteman and was deployed in larger numbers than any other in history. Initial versions carried a single warhead of 0.5 to 1.1 Mt yield, while later versions could carry three or six MIRV warheads. The missile was silo-launched. 15P784 silo design (by KBOM, Design Bureau of Common Machinery, of V.P.Barmin) was greatly simplified in comparison to earlier missiles. Facilities consisted of hardened, un-manned silos controlled by a single central command post. This was the first soviet ICBM (8K84M, entered service on 3 October 1971) equipped with missile defense countermeasure "Palma" by NII-108 of V.Gerasimenko. The UR-100 had a range up to 11,000 km with a light (770 kg) warhead, and a range of 4,000 km with a heavy (1,750 kg) warhead. &br;&br; Payload: 770 - 1750 kg&br; Gross mass: 41,410 kg&br; Thrust: 785 kN&br; Height: 16.93 m&br; Diameter: 2.00 m&br; Max Apogee: 1,000 km.
 
-	notes = Launch the UR-100 ICBM to @/Altitude m altitude.
-	synopsis = <color=yellow>The UR-100 made its first test flight on January 1, 1965 at the Tyuratam, Plesetsk Launch Complex.</color>
-	completedMessage = Mission Success!
+        notes = Launch the UR-100 ICBM to @/Altitude m altitude.
+        synopsis = <color=yellow>The UR-100 made its first test flight on January 1, 1965 at the Tyuratam, Plesetsk Launch Complex.</color>
+        completedMessage = Mission Success!
+        sortKey = 19650101
 
-	agent = USSR
-	deadline = 90
-	minExpiry = 90
-	maxExpiry = 90
-	prestige = trivial
-	cancellable = true
-	declinable = true
-	maxCompletions = 1
-	maxSimultaneous = 1
-	rewardScience = 1
-	rewardReputation = 5
-	rewardFunds = @HistoryofSpaceflight:Kerbucks05
-	failureFunds = @HistoryofSpaceflight:Kerbucks05
-	advanceFunds = @HistoryofSpaceflight:Kerbucks05
+        agent = USSR
+        minExpiry = 0
+        prestige = trivial
+        cancellable = true
+        declinable = true
+        targetBody = HomeWorld()
+        maxCompletions = 1
+        maxSimultaneous = 1
+        rewardScience = 1
+        rewardReputation = 3
+        rewardFunds = @HistoryofSpaceflight:Kerbucks1
+        failureFunds = @HistoryofSpaceflight:Kerbucks1
+        advanceFunds = @HistoryofSpaceflight:Kerbucks1
 
-	DATA
-	{
-		type = double
-		Altitude = 6.429 * (HomeWorld().AtmosphereAltitude())
-		title = Altitude
-	}
+        DATA
+        {
+                type = double
+                // Altitude = 1000km
+                Altitude = (7.143 * (HomeWorld().AtmosphereAltitude())) < HomeWorld().AtmosphereAltitude() ? HomeWorld().AtmosphereAltitude() : (7.143 * (HomeWorld().AtmosphereAltitude()))
+                title = Altitude
+        }
+
+        DATA
+        {
+                type = double
+                // MaxDeltaVee = 6000
+                MaxDeltaVee = 0.0428 * (HomeWorld().AtmosphereAltitude()) * 1.05
+                title = MaxDeltaVee
+        }
+
+        DATA
+        {
+                type = double
+                // MinSpeed = 3100
+                MinSpeed = 0.0221 * (HomeWorld().AtmosphereAltitude())
+                title = MinSpeed
+        }
+
+        PARAMETER
+        {
+                name = UR-100
+                type = VesselParameterGroup
+                title = Launch the UR-100 to @/Altitude m altitude
+                define = UR-100
+                disableOnStateChange = True
+
+                PARAMETER
+                {
+                        name = NewVessel
+                        type = NewVessel
+                        hidden = true
+                }
+
+                PARAMETER
+                {
+                        name = Crewmembers
+                        type = HasCrew
+                        minCrew = 0
+                        maxCrew = 0
+                }
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                maxDeltaVeeVacuum = @/MaxDeltaVee
+                disableOnStateChange = True
+                situation = PRELAUNCH
+                title = Don't exceed @/MaxDeltaVee m/s (vac) delta-V  (bonus)
+                optional = true
+                rewardReputation = 1
+        }
 
 	PARAMETER
 	{
-        name = UR-100
-        type = VesselParameterGroup
-        title = Launch the UR-100 to @/Altitude m altitude
-        define = UR-100
-
-		PARAMETER 
-		{
-			name = NewVessel
-			type = NewVessel
-			hidden = true
-		}
-
-		PARAMETER
-		{
-			name = Crewmembers
-			type = HasCrew
-			minCrew = 0
-			maxCrew = 0
-		}
-
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			minAltitude = @/Altitude
-			disableOnStateChange = True
-			situation = SUB_ORBITAL
-			title = Reach at least @/Altitude m altitude
-			hideChildren = true
-		}
+		name = PartValidation
+		type = PartValidation
+		part = SmallTank
+		minCount = 1
+		disableOnStateChange = true
+		title = Have 770 kg ore payload (bonus)
+                optional = true
+                rewardReputation = 1
 	}
 
-	REQUIREMENT
-	{
-        name = CompleteContract
-        type = CompleteContract
-        contractType = Zond-2
-        minCount =1
-        maxCount =1
-        cooldownDuration = 0d
-	}
-}    
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minSpeed = @/MinSpeed
+                disableOnStateChange = True
+                situation = FLYING
+                situation = SUB_ORBITAL
+                title = Reach at least @/MinSpeed m/s velocity (bonus)
+                optional = true
+                rewardReputation = 1
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minAltitude = @/Altitude
+                disableOnStateChange = True
+                situation = SUB_ORBITAL
+                title = Reach at least @/Altitude m altitude
+        }
+
+        PARAMETER
+        {
+                name = ReachState
+                type = ReachState
+                vessel = UR-100
+                minRateOfClimb = -1
+                maxRateOfClimb = 1
+                minAltitude = @/Altitude
+                maxAltitude = @/Altitude * 1.05
+                disableOnStateChange = true
+                situation = SUB_ORBITAL
+                title = Don't exceed @/Altitude m maximum apogee (bonus)
+                optional = true
+                rewardReputation = 1
+        }
+
+        PARAMETER
+        {
+                name = VesselDestroyed
+                type = VesselDestroyed
+                vessel = UR-100
+                mustImpactTerrain = false
+                title = UR-100 destroyed
+        }
+
+        REQUIREMENT
+        {
+                name = CompleteContract
+                type = CompleteContract
+                contractType = Zond-2
+                minCount =1
+                maxCount =1
+                cooldownDuration = 0d
+        }
+
+        BEHAVIOUR
+        {
+                name = ExperimentalPart
+                type = ExperimentalPart
+                part = SmallTank
+        }
+}

--- a/Stock/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/EarlyMissions/GIRD-9.cfg
+++ b/Stock/GameData/ContractPacks/HistoryofSpaceflight/Missions/SovietMissions/EarlyMissions/GIRD-9.cfg
@@ -13,14 +13,14 @@ CONTRACT_TYPE
 
 	agent = BeforeSputnik
 	minExpiry = 0
-	prestige = trivial
+	prestige = exceptional
 	cancellable = true
 	declinable = true
 	targetBody = HomeWorld()
 	maxCompletions = 1
 	maxSimultaneous = 1
 	rewardScience = 1
-	rewardReputation = 3
+	rewardReputation = 1
 	rewardFunds = @HistoryofSpaceflight:Kerbucks025
 	failureFunds = @HistoryofSpaceflight:Kerbucks025
 	advanceFunds = @HistoryofSpaceflight:Kerbucks025
@@ -28,32 +28,38 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = double
-//		Altitude = 400
-		Altitude = 0.008 * (HomeWorld().FlyingAltitudeThreshold())
+		RealMaxAltitude = 5000
+	}
+
+	DATA
+	{
+		type = double
+		// Altitude = 400
+		Altitude = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 400 : 0.00286 * (HomeWorld().AtmosphereAltitude()))
 		title = Altitude
 	}
 
 	DATA
 	{
 		type = double
-//		MaxAltitude = 5000
-		MaxAltitude = 0.1 * (HomeWorld().FlyingAltitudeThreshold())
+		// MaxAltitude = 5000
+		MaxAltitude = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 5000 : 0.00357 * (HomeWorld().AtmosphereAltitude()))
 		title = MaxAltitude
 	}
 
 	DATA
 	{
 		type = double
-//		MaxDeltaVee = 800
-		MaxDeltaVee = 0.016 * (HomeWorld().FlyingAltitudeThreshold())
+		// MaxDeltaVee = 765
+		MaxDeltaVee = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 765 * 1.05 : 0.00546 * (HomeWorld().AtmosphereAltitude())) * 1.05
 		title = MaxDeltaVee
 	}
 
 	DATA
 	{
 		type = double
-//		MinSpeed = 275
-		MinSpeed = 0.00196 * (HomeWorld().AtmosphereAltitude())
+		// MinSpeed = 275
+		MinSpeed = (@/RealMaxAltitude < HomeWorld().FlyingAltitudeThreshold() ? 275 : 0.00196 * (HomeWorld().AtmosphereAltitude()))
 		title = MinSpeed
 	}
 
@@ -63,6 +69,7 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Launch the GIRD-9 test rocket to @/Altitude m altitude
 		define = GIRD-9
+		disableOnStateChange = True
 
 		PARAMETER
 		{
@@ -80,59 +87,58 @@ CONTRACT_TYPE
 		}
 	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minDeltaVeeActual = 1
-			maxDeltaVeeActual = @/MaxDeltaVee
-			disableOnStateChange = True
-			situation = PRELAUNCH
-			title = Don't exceed @/MaxDeltaVee m/s delta-V (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		maxDeltaVeeVacuum = @/MaxDeltaVee
+		disableOnStateChange = True
+		situation = PRELAUNCH
+                title = Don't exceed @/MaxDeltaVee m/s (vac) delta-V  (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minTerrainAltitude = @/Altitude
-			disableOnStateChange = True
-			situation = FLYING
-			title = Reach at least @/Altitude m altitude
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minTerrainAltitude = @/Altitude
+		disableOnStateChange = True
+		situation = FLYING
+		title = Reach at least @/Altitude m altitude
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minSpeed = @/MinSpeed
-			disableOnStateChange = True
-			situation = FLYING
-			title = Reach at least @/MinSpeed m/s velocity (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minSpeed = @/MinSpeed
+		disableOnStateChange = True
+		situation = FLYING
+		title = Reach at least @/MinSpeed m/s velocity (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
-		PARAMETER
-		{
-			name = ReachState
-			type = ReachState
-			vessel = GIRD-9
-			minRateOfClimb = -1
-			maxRateOfClimb = 1
-			minAltitude = @/MaxAltitude * 0.95
-			maxAltitude = @/MaxAltitude * 1.05
-			disableOnStateChange = true
-			situation = FLYING
-			title = Don't exceed @/MaxAltitude m maximum apogee (bonus)
-			optional = true
-			rewardReputation = 1
-		}
+	PARAMETER
+	{
+		name = ReachState
+		type = ReachState
+		vessel = GIRD-9
+		minRateOfClimb = -1
+		maxRateOfClimb = 1
+		minAltitude = @/MaxAltitude
+		maxAltitude = @/MaxAltitude * 1.05
+		disableOnStateChange = true
+		situation = FLYING
+		title = Don't exceed @/MaxAltitude m maximum apogee (bonus)
+		optional = true
+		rewardReputation = 1
+	}
 
 	PARAMETER
 	{


### PR DESCRIPTION
GIRD-9 Contract Updates
- Increased prestige (first Soviet sounding rocket) and reduced reputation (as it increases with prestige anyway)
- As max apogee is 5km (not exceeding 18km flying low in stock), doesn't matter if stock, JNSQ or RSS, the parameters are roughly the same for altitude, dV, max velocity and max apogee. Added 5% tolerance to max dV
- Switched max dV check to vacuum dV
- Added 5% tolerance to max apogee

UR-100 Contract Updates
- Added vessel stats to description
- Added chronological sortkey
- Reset minExpiry to 0/removed maxExpiry
- Reduced contract reputation to offset bonus reputation
- Increased funds to cover launch cost of vessel
- Added maxdV bonus
- Added payload bonus
- Added max speed bonus
- Added max apogee bonus
- Added vessel destruction